### PR TITLE
refactor: useDragIndexCarousel 인터페이스 useDragCarousel과 통합

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,25 @@ you can set `startIndex` and `minMove`.
 
 `minMove` : Minimum movement required for the index to shift.
 
-### useDragCarouselIndex
+#### parameters
 
-This hook should be called within the carousel provider provided by the useDragIndexCarousel component.
-carousel provider renders children elements. It already has the `display: flex` property included.
+`dataLength`, `startIndex`, `minMove`
 
-you can get current index in carousel children.
+`startIndex` : specifies the start index.
+
+`minMove`: determines how many slides you have to slide over.
+
+#### return values
+
+useDragCarousel returns `CarouselWrapper`, `next`, `prev`, `index`, `ref`, `isEnd`, `isStart`
+
+`CarouselWrapper`: renders children elements. It already contains `display:flex` property.
+
+`ref`: you need to assign a ref to the Carousel Wrapper.
+
+`next`: increase index
+
+`prev`: decrease index
 
 ### useCarousel
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapiders/react-hooks",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "react hooks for fast development",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import useInput from './useInput/useInput';
 import useAnimation from './useAnimation/useAnimation';
 import useFocusAnimation from './useFocusAnimation/useFocusAnimation';
-import { useDragCarouselIndex } from './useDragIndexCarousel/useDragIndexCarousel';
 import useDragIndexCarousel from './useDragIndexCarousel/useDragIndexCarousel';
 import useCarousel from './useCarousel/useCarousel';
 import useScrollRatio from './useScrollRatio';
@@ -10,7 +9,6 @@ export {
   useInput,
   useAnimation,
   useFocusAnimation,
-  useDragCarouselIndex,
   useDragIndexCarousel,
   useCarousel,
   useScrollRatio,

--- a/src/stories/useDragIndexCarousel/DragCarousel.tsx
+++ b/src/stories/useDragIndexCarousel/DragCarousel.tsx
@@ -8,9 +8,10 @@ export default function DragCarousel() {
     'https://image.xportsnews.com/contents/images/upload/article/2023/0825/mb_1692925582785123.jpg',
     'https://photo.newsen.com/news_photo/2022/08/19/202208190935355510_1.jpg',
   ];
-  const DragCarousel = useDragIndexCarousel();
+  const { CarouselWrapper, ref } = useDragIndexCarousel(images.length);
   return (
-    <DragCarousel
+    <CarouselWrapper
+      ref={ref}
       style={{
         width: 500,
         height: 500,
@@ -38,6 +39,6 @@ export default function DragCarousel() {
           />
         </div>
       ))}
-    </DragCarousel>
+    </CarouselWrapper>
   );
 }

--- a/src/useDragIndexCarousel/useDragIndexCarousel.test.tsx
+++ b/src/useDragIndexCarousel/useDragIndexCarousel.test.tsx
@@ -1,12 +1,13 @@
 import { renderHook, act } from '@testing-library/react';
-import { _useDragIndexCarousel } from './useDragIndexCarousel';
+import useDragIndexCarousel from './useDragIndexCarousel';
+import {_useDragIndexCarousel} from './useDragIndexCarousel';
 
-describe('_useDragIndexCarousel', () => {
+
+describe('useDragIndexCarousel', () => {
   it('초기 상태 테스트 index로 시작할 수 있다.', () => {
     const { result } = renderHook(() => _useDragIndexCarousel(3));
 
     expect(result.current.index).toBe(0);
-    expect(result.current.style.transform).toBe('translateX(0px)');
   });
 
   it('모바일 터치이벤트 테스트: 절대값으로 minMove보다 많이, 오른쪽으로 슬라이드하면 index를 증가시킬 수 있다.', () => {

--- a/src/useDragIndexCarousel/useDragIndexCarousel.tsx
+++ b/src/useDragIndexCarousel/useDragIndexCarousel.tsx
@@ -1,16 +1,12 @@
-import React, { CSSProperties, ReactElement, cloneElement } from 'react';
+import React, {
+  CSSProperties,
+  ForwardedRef,
+  ReactElement,
+  cloneElement,
+  forwardRef,
+  useEffect,
+} from 'react';
 import { useRef, useState, Children, ReactNode } from 'react';
-import { createContext, useContext } from 'react';
-
-export const CarouselIndex = createContext<number | null>(null);
-
-export const useDragCarouselIndex = () => {
-  const result = useContext(CarouselIndex);
-  if (result) return result;
-  throw new Error(
-    'Check the provider: You have to use CarouselIndex in IndexCarouselProvider children'
-  );
-};
 
 export function _useDragIndexCarousel(
   pageLimit: number,
@@ -62,104 +58,105 @@ export function _useDragIndexCarousel(
     setTouchStartX(0);
   };
 
-  const style = {
-    display: 'flex',
-    transform: `translateX(${-index * getSliderWidth() + transX}px)`,
-    transitionDuration: '300ms',
-    transitionTimingFunction: 'ease-out',
+  const getNext = (index: number) => {
+    if (index < pageLimit - 1) return index + 1;
+    return index;
   };
+
+  const getPrev = (index: number) => {
+    if (index > 0) return index - 1;
+    return index;
+  };
+
+  const next = () => setIndex((prev) => getNext(prev));
+  const prev = () => setIndex((prev) => getPrev(prev));
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.display = 'flex';
+      ref.current.style.transform = `translateX(${-index * getSliderWidth() + transX}px)`;
+      ref.current.style.transitionDuration = '300ms';
+      ref.current.style.transitionTimingFunction = 'ease-out';
+    }
+  }, [transX]);
 
   return {
-    style,
     ref,
+    isEnd: index === pageLimit,
+    isStart: index === 0,
     handleTouchStart,
     handleTouchMove,
     handleMoveEnd,
     handleScrollStart,
     handleScrollMove,
+    next,
+    prev,
     index,
   };
 }
 
-function DragIndexCarousel({
-  startIndex,
-  minMove,
-  style,
-  className,
-  children,
-}: {
-  startIndex: number;
-  minMove?: number;
-  style?: CSSProperties;
-  className?: string;
-  children: ReactNode;
-}) {
-  const pageLimit = Children.count(children) - 1;
-  const {
-    index,
-    ref,
-    style: dragStyle,
-    handleTouchStart,
-    handleTouchMove,
-    handleMoveEnd,
-    handleScrollStart,
-    handleScrollMove,
-  } = _useDragIndexCarousel(pageLimit, minMove, startIndex);
-
-  return (
-    <div
-      style={{
-        overflow: 'hidden',
-        ...style,
-      }}
-      className={className}
-      draggable={false}
-    >
-      <div
-        ref={ref}
-        style={{ ...dragStyle, height: '100%', width: '100%' }}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleMoveEnd}
-        onMouseDown={handleScrollStart}
-        onMouseMove={handleScrollMove}
-        onMouseUp={handleMoveEnd}
-        onMouseLeave={handleMoveEnd}
-      >
-        <CarouselIndex.Provider value={index}>
-          {children}
-        </CarouselIndex.Provider>
-      </div>
-    </div>
-  );
-}
-
-export default function useDragIndexCarousel(startIndex = 0, minMove = 60) {
-  const component = ({
-    children,
-    className,
-    style,
-  }: {
-    children: ReactNode;
-    style?: CSSProperties;
-    className?: string;
-  }) => {
-    return (
-      <DragIndexCarousel
-        startIndex={startIndex}
-        minMove={minMove}
-        style={style}
-        className={className}
-      >
+const CarouselWrapper = forwardRef(
+  (
+    {
+      children,
+      style,
+      className,
+    }: { children: ReactNode; style?: React.CSSProperties; className?: string },
+    ref: ForwardedRef<HTMLDivElement>
+  ) => (
+    <div style={{ overflow: 'hidden', ...style }} className={className}>
+      <div ref={ref} style={{ height: '100%', width: '100%' }}>
         {Children.map(children, (child: ReactElement) =>
           cloneElement(child, {
             style: { ...child.props.style, flexShrink: 0 },
-            draggable: false,
           })
         )}
-      </DragIndexCarousel>
-    );
-  };
+      </div>
+    </div>
+  )
+);
 
-  return component;
+export default function useDragIndexCarousel(
+  dataLength: number,
+  startIndex = 0,
+  minMove = 60
+) {
+  const {
+    index,
+    ref,
+    handleTouchStart,
+    handleTouchMove,
+    handleMoveEnd,
+    handleScrollStart,
+    handleScrollMove,
+    next,
+    prev,
+    isEnd,
+    isStart,
+  } = _useDragIndexCarousel(dataLength - 1, minMove, startIndex);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.addEventListener('touchstart', handleTouchStart as any);
+      ref.current.addEventListener('touchmove', handleTouchMove as any);
+      ref.current.addEventListener('touchend', handleMoveEnd as any);
+      ref.current.addEventListener('mousedown', handleScrollStart as any);
+      ref.current.addEventListener('mouseleave', handleMoveEnd as any);
+      ref.current.addEventListener('mousemove', handleScrollMove as any);
+      ref.current.addEventListener('mouseup', handleMoveEnd as any);
+    }
+    return () => {
+      if (ref.current) {
+        ref.current.removeEventListener('touchstart', handleTouchStart as any);
+        ref.current.removeEventListener('touchmove', handleTouchMove as any);
+        ref.current.removeEventListener('touchend', handleMoveEnd as any);
+        ref.current.removeEventListener('mousedown', handleScrollStart as any);
+        ref.current.removeEventListener('mouseleave', handleMoveEnd as any);
+        ref.current.removeEventListener('mousemove', handleScrollMove as any);
+        ref.current.removeEventListener('mouseup', handleMoveEnd as any);
+      }
+    };
+  });
+
+  return { CarouselWrapper, index, ref, next, prev, isStart, isEnd };
 }


### PR DESCRIPTION
- [x] refactor: useDragIndexCarousel 인터페이스 useDragCarousel과 통합

### 배경
1. Next에서 window객체를 찾을 수 없어 SSR에서 useDragIndexCarousel이 제대로 작동하지 않음 (getSliderWidth함수에서 window객체 참조)
2. 이는 style객체를 따로 생성했기때문에 발생했던 문제인데, useCarousel에서는 이런 문제를 이미 해결했었음
3. ref.current를 통해 style속성을 적용시키는 방식으로 변경
4. 다시보니 useDragCarousel과 인터페이스가 다른 부분이 많아 통합 처리

### 변경점
1. useDrageIndexCarousel 반환값 추가, 수정
2. useDragCarouselndex 훅 삭제