### PR TITLE
feat: useDragIndexCarousel Infinity mode추가, useInterval 훅 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,27 +87,29 @@ You have to register ref to animation HTMLElement.
 
 With "useDragIndexCarousel," you can easily implement a dragable Index Carousel.
 
-you can set `startIndex` and `minMove`.
-
-`minMove` : Minimum movement required for the index to shift.
-
 #### parameters
 
-`dataLength`, `startIndex`, `minMove`
+`dataLength`, `options`
+
+`options`: let you adjust the option of the carousel.
 
 `startIndex` : specifies the start index.
+
+`infinity` : Specifies whether to loop back to the beginning when the carousel reaches the end.
 
 `minMove`: determines how many slides you have to slide over.
 
 #### return values
 
-useDragCarousel returns `CarouselWrapper`, `next`, `prev`, `index`, `ref`, `isEnd`, `isStart`
+useDragCarousel returns `isDragging`, `CarouselWrapper`, `next`, `prev`, `index`, `ref`, `isEnd`, `isStart`
+
+`isDragging`: Indicates whether the element is being dragged or not.
 
 `CarouselWrapper`: renders children elements. It already contains `display:flex` property.
 
 `ref`: you need to assign a ref to the Carousel Wrapper.
 
-`next`: increase index
+`next`: increase index.
 
 `prev`: decrease index
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Test code is not fully prepared yet. Please note.
 npm install @rapiders/react-hooks
 ```
 
+## Hooks
+
 ### useInput
 
 simple hook to change input components(uncontroll component) to controll component
@@ -25,6 +27,16 @@ simple hook to change input components(uncontroll component) to controll compone
         <input value={value} onChange={onChange}/>
         <button onClick={reset}>RESET</button>
     </div>
+```
+
+### useInterval
+
+simple hook to setInterval with React Component
+
+```tsx
+...
+const callback = () => {};
+const { continueTimer, stop } = useInterval(callback, 1000); //1000ms
 ```
 
 ## Animation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapiders/react-hooks",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "react hooks for fast development",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import useFocusAnimation from './useFocusAnimation/useFocusAnimation';
 import useDragIndexCarousel from './useDragIndexCarousel/useDragIndexCarousel';
 import useCarousel from './useCarousel/useCarousel';
 import useScrollRatio from './useScrollRatio';
+import useInterval from './useInterval/useInterval';
 
 export {
   useInput,
@@ -12,4 +13,5 @@ export {
   useDragIndexCarousel,
   useCarousel,
   useScrollRatio,
+  useInterval,
 };

--- a/src/stories/useDragIndexCarousel/Docs.mdx
+++ b/src/stories/useDragIndexCarousel/Docs.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Meta, Description } from '@storybook/blocks';
-import * as DragCarouselStories from './DragCarousel.stories';
+import * as DragCarouselStories from './TimerDragCarousel.stories';
 
 <Meta of={DragCarouselStories} />
 
@@ -9,4 +9,76 @@ useDragCarousel에서 반환된 컴포넌트를 통해 간편하게 Drag가능�
 
 모바일, PC 환경 모두 지원합니다.
 
-<Canvas of={DragCarouselStories.defaultStory} />
+## 함수인자
+
+DragIndexCarousel에서 보여줄 데이터 길이와 optional 형태로 options객체를 받습니다.
+
+`startIndex`를 통해 Carousel의 시작 index를 지정할 수 있습니다.
+
+`infinity`를 통해 Carousel이 끝에 도달했을 때 다음 요소를 보여줄지, 아니면 처음 요소로 돌아갈지를 결정할 수 있습니다.
+
+`minMove`를 통해 얼마나 드래그해야 index가 변경되는지를 지정할 수 있습니다.
+
+## 반환값
+
+`isDragging` : 지금 슬라이더가 drag되고 있는지 상태를 반환합니다.
+
+`next` : 다음 요소로 넘깁니다.
+
+`prev` : 이전 요소로 넘깁니다.
+
+`CarouselWrapper` : 해당 요소에 ref를 넣어주어 Carousel 내부 데이터를 렌더링하는 Wrapper로 사용합니다. 기본적인 Carousel style이 지정되어있으며, 추가로 style을 부여할 수 있습니다.
+
+`ref`: CarouselWrapper에 주입해줄 ref 객체입니다.
+
+`isEnd`: Carousel이 마지막 요소에 도달했는지 표시하는 상태입니다.
+
+`isStart`: Carousel이 첫 요소에 도달했는지 표시하는 상태입니다.
+
+`index`: 현재 화면에 보이는 인덱스를 반환합니다.
+
+<Canvas of={DragCarouselStories.timerStory} />
+
+### 기본 사용 예시
+
+```typescript
+import useDragIndexCarousel from '../../useDragIndexCarousel/useDragIndexCarousel';
+import React from 'react';
+
+export default function DragCarousel() {
+  const images = [...];
+  const { CarouselWrapper, ref } = useDragIndexCarousel(images.length);
+  return (
+    <CarouselWrapper
+      ref={ref}
+      style={{
+        width: 500,
+        height: 500,
+      }}
+    >
+      {images.map((image) => (
+        <div
+          style={{
+            width: '100%',
+            backgroundColor: 'black',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <img
+            src={image}
+            draggable={false}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'contain',
+            }}
+          />
+        </div>
+      ))}
+    </CarouselWrapper>
+  );
+}
+```

--- a/src/stories/useDragIndexCarousel/DragCarousel.tsx
+++ b/src/stories/useDragIndexCarousel/DragCarousel.tsx
@@ -6,7 +6,7 @@ export default function DragCarousel() {
     'https://i.namu.wiki/i/8BAuDmjlFbHoGpGTyTUJyeIsrWw7vrGKTvbOBS1DbaLNHHFL6D05TSZEyVGGffn_RIs6zrf4jCb5Xq5Lnbs8QQ.webp',
     'https://cdn.topstarnews.net/news/photo/202208/14724511_938042_3651.jpg',
     'https://image.xportsnews.com/contents/images/upload/article/2023/0825/mb_1692925582785123.jpg',
-    'https://photo.newsen.com/news_photo/2022/08/19/202208190935355510_1.jpg',
+    'https://cdn.entermedia.co.kr/news/photo/202210/30302_58507_3849.jpg',
   ];
   const { CarouselWrapper, ref } = useDragIndexCarousel(images.length);
   return (

--- a/src/stories/useDragIndexCarousel/TimerDragCarousel.stories.ts
+++ b/src/stories/useDragIndexCarousel/TimerDragCarousel.stories.ts
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import DragCarousel from './DragCarousel';
+import TimerDragCarousel from './TimerDragCarousel';
+
+const meta = {
+  title: 'hooks/useDragCarousel',
+  component: TimerDragCarousel,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      canvas: {},
+    },
+  },
+} satisfies Meta<typeof TimerDragCarousel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const timerStory: Story = {};

--- a/src/stories/useDragIndexCarousel/TimerDragCarousel.tsx
+++ b/src/stories/useDragIndexCarousel/TimerDragCarousel.tsx
@@ -1,0 +1,57 @@
+import useDragIndexCarousel from '../../useDragIndexCarousel/useDragIndexCarousel';
+import useInterval from '../../useInterval/useInterval';
+
+import React, { useEffect } from 'react';
+
+export default function TimerDragCarousel() {
+  const images = [
+    'https://i.namu.wiki/i/8BAuDmjlFbHoGpGTyTUJyeIsrWw7vrGKTvbOBS1DbaLNHHFL6D05TSZEyVGGffn_RIs6zrf4jCb5Xq5Lnbs8QQ.webp',
+    'https://cdn.topstarnews.net/news/photo/202208/14724511_938042_3651.jpg',
+    'https://image.xportsnews.com/contents/images/upload/article/2023/0825/mb_1692925582785123.jpg',
+    'https://cdn.entermedia.co.kr/news/photo/202210/30302_58507_3849.jpg',
+  ];
+  const { CarouselWrapper, ref, next, isDragging } = useDragIndexCarousel(
+    images.length,
+    {
+      infinity: true,
+    }
+  );
+  const { continueTimer, stop } = useInterval(next, 3000);
+  useEffect(() => {
+    if (isDragging) stop();
+    else continueTimer();
+  }, [isDragging]);
+
+  return (
+    <CarouselWrapper
+      ref={ref}
+      style={{
+        width: 500,
+        height: 500,
+      }}
+    >
+      {images.map((image) => (
+        <div
+          style={{
+            width: '100%',
+            backgroundColor: 'black',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <img
+            src={image}
+            draggable={false}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'contain',
+            }}
+          />
+        </div>
+      ))}
+    </CarouselWrapper>
+  );
+}

--- a/src/useDragIndexCarousel/useDragIndexCarousel.tsx
+++ b/src/useDragIndexCarousel/useDragIndexCarousel.tsx
@@ -1,12 +1,14 @@
 import React, {
-  CSSProperties,
   ForwardedRef,
   ReactElement,
   cloneElement,
   forwardRef,
   useEffect,
+  useRef,
+  useState,
+  Children,
+  ReactNode,
 } from 'react';
-import { useRef, useState, Children, ReactNode } from 'react';
 
 interface useDragIndexCarouselOptions {
   minMove?: number;
@@ -26,20 +28,20 @@ export function _useDragIndexCarousel(
   const [index, setIndex] = useState(startIndex);
   const ref = useRef<HTMLDivElement>(null);
 
-  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+  const handleTouchStart = (e: TouchEvent) => {
     setTouchStartX(e.touches[0].clientX);
   };
-  const handleScrollStart = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleScrollStart = (e: MouseEvent) => {
     setMouseDown(true);
     setTouchStartX(e.pageX);
   };
 
-  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+  const handleTouchMove = (e: TouchEvent) => {
     const moveWidth = e.touches[0].clientX - touchStartX;
     setTransX(moveWidth);
   };
 
-  const handleScrollMove = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleScrollMove = (e: MouseEvent) => {
     if (isMouseDown) {
       const moveWidth = e.pageX - touchStartX;
       setTransX(moveWidth);
@@ -78,10 +80,10 @@ export function _useDragIndexCarousel(
   const reconcileIndex = () => {
     const resetToFirstPage = () => {
       if (ref.current) {
-        ref.current!.style.transition = 'none';
-        ref.current!.style.transform = `translateX(${-getSliderWidth()}px)`;
+        ref.current.style.transition = 'none';
+        ref.current.style.transform = `translateX(${-getSliderWidth()}px)`;
         setIndex(1);
-        ref.current!.removeEventListener('transitionend', resetToFirstPage);
+        ref.current.removeEventListener('transitionend', resetToFirstPage);
       }
     };
     const resetToLastPage = () => {
@@ -187,13 +189,13 @@ export default function useDragIndexCarousel(
 
   useEffect(() => {
     if (ref.current) {
-      ref.current.addEventListener('touchstart', handleTouchStart as any);
-      ref.current.addEventListener('touchmove', handleTouchMove as any);
-      ref.current.addEventListener('touchend', handleMoveEnd as any);
-      ref.current.addEventListener('mousedown', handleScrollStart as any);
-      ref.current.addEventListener('mouseleave', handleMoveEnd as any);
-      ref.current.addEventListener('mousemove', handleScrollMove as any);
-      ref.current.addEventListener('mouseup', handleMoveEnd as any);
+      ref.current.addEventListener('touchstart', handleTouchStart);
+      ref.current.addEventListener('touchmove', handleTouchMove);
+      ref.current.addEventListener('touchend', handleMoveEnd);
+      ref.current.addEventListener('mousedown', handleScrollStart);
+      ref.current.addEventListener('mouseleave', handleMoveEnd);
+      ref.current.addEventListener('mousemove', handleScrollMove);
+      ref.current.addEventListener('mouseup', handleMoveEnd);
     }
     return () => {
       if (ref.current) {

--- a/src/useDragIndexCarousel/useDragIndexCarousel.tsx
+++ b/src/useDragIndexCarousel/useDragIndexCarousel.tsx
@@ -8,10 +8,17 @@ import React, {
 } from 'react';
 import { useRef, useState, Children, ReactNode } from 'react';
 
+interface useDragIndexCarouselOptions {
+  minMove?: number;
+  startIndex?: number;
+  infinity?: boolean;
+}
+
 export function _useDragIndexCarousel(
   pageLimit: number,
   minMove = 60,
-  startIndex = 0
+  startIndex = 0,
+  infinity = false
 ) {
   const [isMouseDown, setMouseDown] = useState(false);
   const [touchStartX, setTouchStartX] = useState(0);
@@ -48,12 +55,9 @@ export function _useDragIndexCarousel(
 
   const handleMoveEnd = () => {
     setMouseDown(false);
-    const limitPage = pageLimit;
-    if (transX > minMove) {
-      setIndex((prev) => (prev > 0 ? prev - 1 : prev));
-    } else if (transX < -minMove) {
-      setIndex((prev) => (prev < limitPage ? prev + 1 : prev));
-    }
+    if (transX > minMove) setIndex((prev) => getPrev(prev));
+    else if (transX < -minMove) setIndex((prev) => getNext(prev));
+
     setTransX(0);
     setTouchStartX(0);
   };
@@ -71,16 +75,52 @@ export function _useDragIndexCarousel(
   const next = () => setIndex((prev) => getNext(prev));
   const prev = () => setIndex((prev) => getPrev(prev));
 
+  const reconcileIndex = () => {
+    const resetToFirstPage = () => {
+      if (ref.current) {
+        ref.current!.style.transition = 'none';
+        ref.current!.style.transform = `translateX(${-getSliderWidth()}px)`;
+        setIndex(1);
+        ref.current!.removeEventListener('transitionend', resetToFirstPage);
+      }
+    };
+    const resetToLastPage = () => {
+      if (ref.current) {
+        ref.current!.style.transition = 'none';
+        ref.current!.style.transform = `translateX(${-(pageLimit - 1) * getSliderWidth()}px)`;
+        setIndex(pageLimit - 1);
+        ref.current!.removeEventListener('transitionend', resetToLastPage);
+      }
+    };
+
+    if (index === pageLimit && ref.current)
+      ref.current.addEventListener('transitionend', resetToFirstPage);
+
+    if (index === 0 && ref.current)
+      ref.current.addEventListener('transitionend', resetToLastPage);
+  };
+
+  // initialize index with infinity options
   useEffect(() => {
     if (ref.current) {
+      ref.current.style.transition = 'none';
+      ref.current.style.transform = `translateX(${-index * getSliderWidth() + transX}px)`;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.transition = 'all';
       ref.current.style.display = 'flex';
       ref.current.style.transform = `translateX(${-index * getSliderWidth() + transX}px)`;
       ref.current.style.transitionDuration = '300ms';
       ref.current.style.transitionTimingFunction = 'ease-out';
     }
-  }, [transX]);
+    if (infinity) reconcileIndex();
+  }, [transX, index]);
 
   return {
+    isDragging: transX !== 0,
     ref,
     isEnd: index === pageLimit,
     isStart: index === 0,
@@ -118,10 +158,20 @@ const CarouselWrapper = forwardRef(
 
 export default function useDragIndexCarousel(
   dataLength: number,
-  startIndex = 0,
-  minMove = 60
+  options?: useDragIndexCarouselOptions
 ) {
+  const getStartIndex = () => {
+    if (!options) return 0;
+    if (options.infinity) return (options.startIndex || 0) + 1;
+    return options.startIndex || 0;
+  };
+  const minMove = options?.minMove || 60;
+  const startIndex = getStartIndex();
+  const infinity = options?.infinity || false;
+  const realDataLength = infinity ? dataLength + 1 : dataLength - 1;
+
   const {
+    isDragging,
     index,
     ref,
     handleTouchStart,
@@ -133,7 +183,7 @@ export default function useDragIndexCarousel(
     prev,
     isEnd,
     isStart,
-  } = _useDragIndexCarousel(dataLength - 1, minMove, startIndex);
+  } = _useDragIndexCarousel(realDataLength, minMove, startIndex, infinity);
 
   useEffect(() => {
     if (ref.current) {
@@ -158,5 +208,39 @@ export default function useDragIndexCarousel(
     };
   });
 
-  return { CarouselWrapper, index, ref, next, prev, isStart, isEnd };
+  // when Infinity options
+  useEffect(() => {
+    if (infinity && ref.current) {
+      if (ref.current.lastElementChild && ref.current.firstElementChild) {
+        const lastElement = ref.current.lastElementChild;
+        const firstElement = ref.current.firstElementChild;
+        ref.current.insertBefore(
+          lastElement.cloneNode(true),
+          ref.current.firstElementChild
+        );
+        ref.current.appendChild(firstElement.cloneNode(true));
+      }
+    }
+  }, []);
+
+  const getDisplayIndex = () => {
+    if (infinity) {
+      const displayIndex = index - 1;
+      if (displayIndex > dataLength - 1) return dataLength - 1;
+      if (displayIndex < 0) return 0;
+      return displayIndex;
+    }
+    return index;
+  };
+
+  return {
+    isDragging,
+    CarouselWrapper,
+    index: getDisplayIndex(),
+    ref,
+    next,
+    prev,
+    isStart,
+    isEnd,
+  };
 }

--- a/src/useInterval/useInterval.test.ts
+++ b/src/useInterval/useInterval.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import useInterval from './useInterval';
+import { act } from 'react-dom/test-utils';
+
+describe('useInterval 기능 테스트', () => {
+  jest.useFakeTimers();
+  it('지정된 시간 후에 callback을 주기적으로 수행할 수 있다.', () => {
+    const callback = jest.fn();
+    const delay = 1000;
+    renderHook(() => useInterval(callback, delay));
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(1);
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(2);
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it('stop을 호출하면 callback호출하는 interval을 멈출 수 있다.', () => {
+    const callback = jest.fn();
+    const delay = 1000;
+    const { result } = renderHook(() => useInterval(callback, delay));
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(1);
+    act(() => result.current.stop());
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop을 호출하여 멈춘 상태에서 continueTimer를 통해 callback호출하는 interval을 재시작 할 수 있다.', () => {
+    const callback = jest.fn();
+    const delay = 1000;
+    const { result } = renderHook(() => useInterval(callback, delay));
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(1);
+    act(() => result.current.stop());
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(1);
+    act(() => result.current.continueTimer());
+    act(() => jest.advanceTimersByTime(delay));
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/useInterval/useInterval.ts
+++ b/src/useInterval/useInterval.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useInterval(callback: () => void, delay: number) {
+  const [timer, setTimer] = useState(true);
+
+  const stop = () => setTimer(false);
+  const continueTimer = () => setTimer(true);
+
+  const savedCallback = useRef(callback);
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+  useEffect(() => {
+    const tick = () => {
+      if (timer) savedCallback.current();
+    };
+    const timerId = setInterval(tick, delay);
+    return () => clearInterval(timerId);
+  }, [delay, timer]);
+
+  return { stop, continueTimer };
+}


### PR DESCRIPTION
- [x] useDragIndexCarousel infinity mode 추가
- [x] useInterval 훅 추가

### infinity mode추가
drag Carousel 에 infinity mode를 추가하였습니다.

https://github.com/Rapiders/react-hooks/assets/99241871/04ef8df3-e093-43c2-a455-7da2a29c854e

요소 앞뒤로 최후방요소와 최상단 요소를 복사하여 각각 추가하고, index를 translate계산할때에 적용하여 자연스럽게 보일 수 있도록 처리했습니다.

#### 최후방요소에 도달한 경우
1. transition 옵션을 none으로 지정하여 유저가 transform조정을 알아챌 수 없도록 함
2. translate를 최초 인덱스 +1만큼 이동하여 위치 이동
3. 기존 traslate계산 전에 transition을 all으로 변경하여 다시 슬라이더가 자연스럽게 이동할 수 있도록 처리

### useInterval 추가
setInterval을 컴포넌트 내부에서 멈췄다 다시 진행시켰다 하는 부분이 내부 렌더링 로직에 의해 의도대로 동작하지 않는 문제를 해결하기 위한 훅인 useInterval 기능을 추가하였습니다.

