### PR TITLE
test: useDragIndexCarousel test coverage 개선

### DIFF
--- a/src/useDragIndexCarousel/_useDragIndexCarousel.test.tsx
+++ b/src/useDragIndexCarousel/_useDragIndexCarousel.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook, act } from '@testing-library/react';
+import { _useDragIndexCarousel } from './useDragIndexCarousel';
+
+describe('_useDragIndexCarousel 기능 테스트', () => {
+  it('초기 상태 테스트 index로 시작할 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3));
+
+    expect(result.current.index).toBe(0);
+  });
+
+  it('index를 next, prev로 조작할 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(2));
+
+    expect(result.current.index).toBe(0);
+    act(() => result.current.next());
+    expect(result.current.index).toBe(1);
+    act(() => result.current.prev());
+    expect(result.current.index).toBe(0);
+    expect(result.current.isStart).toBe(true);
+    act(() => result.current.next());
+    act(() => result.current.next());
+    expect(result.current.isEnd).toBe(true);
+  });
+
+  it('모바일 터치이벤트 테스트: 절대값으로 minMove보다 많이, 오른쪽으로 슬라이드하면 index를 증가시킬 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3, 60));
+    const touchEvent = { touches: [{ clientX: 0 }] };
+    const touchMove = { touches: [{ clientX: -100 }] };
+
+    act(() => result.current.handleTouchStart(touchEvent as unknown as TouchEvent));
+    act(() => result.current.handleTouchMove(touchMove as unknown as TouchEvent));
+    act(() => result.current.handleMoveEnd());
+
+    expect(result.current.index).toBe(1);
+  });
+
+  it('모바일 터치이벤트 테스트: 절대값으로 minMove보다 많이, 왼쪽으로 슬라이드하면 index를 감소시킬 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3, 60, 1));
+    const touchEvent = { touches: [{ clientX: 0 }] };
+    const touchMove = { touches: [{ clientX: 100 }] };
+
+    act(() => result.current.handleTouchStart(touchEvent as unknown as TouchEvent));
+    act(() => result.current.handleTouchMove(touchMove as unknown as TouchEvent));
+    act(() => result.current.handleMoveEnd());
+
+    expect(result.current.index).toBe(0);
+  });
+
+  it('모바일 터치이벤트 테스트: 절대값으로 minMove보다 적게,  슬라이드하면 index를 유지시킬 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3, 100));
+    const touchEvent = { touches: [{ clientX: 0 }] };
+    const touchMove = { touches: [{ clientX: -90 }] };
+
+    act(() => result.current.handleTouchStart(touchEvent as unknown as TouchEvent));
+    act(() => result.current.handleTouchMove(touchMove as unknown as TouchEvent));
+    act(() => result.current.handleMoveEnd());
+
+    expect(result.current.index).toBe(0);
+  });
+
+  it('PC 스크롤이벤트 테스트: 절대값으로 minMove보다 많이, 오른쪽으로 슬라이드하면 index를 증가시킬 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3, 60));
+    const touchEvent = { pageX: 0 };
+    const touchMove = { pageX: -100 };
+
+    act(() => result.current.handleScrollStart(touchEvent as MouseEvent));
+    act(() => result.current.handleScrollMove(touchMove as MouseEvent));
+    act(() => result.current.handleMoveEnd());
+
+    expect(result.current.index).toBe(1);
+  });
+
+  it('PC 스크롤이벤트 테스트: 절대값으로 minMove보다 많이, 왼쪽으로 슬라이드하면 index를 감소시킬수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3, 60, 1));
+    const touchEvent = { pageX: 0 };
+    const touchMove = { pageX: 100 };
+
+    act(() => result.current.handleScrollStart(touchEvent as MouseEvent));
+    act(() => result.current.handleScrollMove(touchMove as MouseEvent));
+    act(() => result.current.handleMoveEnd());
+
+    expect(result.current.index).toBe(0);
+  });
+
+  it('PC 스크롤이벤트 테스트: 절대값으로 minMove보다 적게 슬라이드하면 index를 유지시킬 수 있다.', () => {
+    const { result } = renderHook(() => _useDragIndexCarousel(3, 100, 1));
+    const touchEvent = { pageX: 0 };
+    const touchMove = { pageX: 60 };
+
+    act(() => result.current.handleScrollStart(touchEvent as MouseEvent));
+    act(() => result.current.handleScrollMove(touchMove as MouseEvent));
+    act(() => result.current.handleMoveEnd());
+
+    expect(result.current.index).toBe(1);
+  });
+});

--- a/src/useDragIndexCarousel/useDragIndexCarousel.tsx
+++ b/src/useDragIndexCarousel/useDragIndexCarousel.tsx
@@ -34,10 +34,9 @@ export function _useDragIndexCarousel(pageLimit: number, minMove = 60, startInde
   };
 
   const getSliderWidth = () => {
-    if (ref.current) {
-      return ref.current.clientWidth;
-    }
-    return window.innerWidth;
+    // getSliderWidth는 상단의 useEffect에서 호출하는데, 여기서 ref.current를 확인하므로
+    // ref.current가 반드시 존재한다.
+    return ref!.current!.clientWidth;
   };
 
   const handleMoveEnd = () => {


### PR DESCRIPTION
- [x] useDragIndexCarousel 테스트 커버리지 개선

### Before
![image](https://github.com/Rapiders/react-hooks/assets/99241871/9e371332-636c-4751-b0b0-07c45fee7996)

### After
![image](https://github.com/Rapiders/react-hooks/assets/99241871/8d499531-2c71-4195-8036-8b8467949752)

### Comment
jsdom 에서 pageX와 clientX를 지원하지 않는 문제가 있어 object.defineProperty를 사용하여 모킹하였습니다.
```typescript
beforeAll(() => {
  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
    configurable: true,
    value: WRAPPER_WIDTH,
  });

  Object.defineProperties(MouseEvent.prototype, {
    pageX: {
      get() {
        return this.clientX;
      },
    },
  });
});
```
관련 이슈
- https://github.com/jsdom/jsdom/issues/1911
- https://github.com/jsdom/jsdom/issues/2310
- https://github.com/jsdom/jsdom/issues/1322
