### PR TITLE
test: useAnimation test coverage 개선

### DIFF
--- a/src/useAnimation/_useAnimation.test.ts
+++ b/src/useAnimation/_useAnimation.test.ts
@@ -5,9 +5,13 @@ const MOUNT_ANIMATION_CLASSNAME = 'mountAnimation';
 const UNMOUNT_ANIMATION_CLASSNAME = 'unmountAnimation';
 
 describe('useAnimation Test', () => {
-  it('triggerUnmountAnimation이 수행되면 unmountAnimationClassName으로 상태를 변경할 수 있다.', () => {
+  it('최초 훅 실행시 mount animation className이 부여된다.', () => {
     const { result } = renderHook(() => _useAnimation(MOUNT_ANIMATION_CLASSNAME, UNMOUNT_ANIMATION_CLASSNAME));
     expect(result.current.animationClassName).toBe(MOUNT_ANIMATION_CLASSNAME);
+  });
+
+  it('triggerUnmountAnimation이 수행되면 unmountAnimationClassName으로 상태를 변경할 수 있다.', () => {
+    const { result } = renderHook(() => _useAnimation(MOUNT_ANIMATION_CLASSNAME, UNMOUNT_ANIMATION_CLASSNAME));
     act(() => result.current.triggerUnmountAnimation());
     expect(result.current.animationClassName).toBe(UNMOUNT_ANIMATION_CLASSNAME);
   });
@@ -15,7 +19,6 @@ describe('useAnimation Test', () => {
   it('handleUnmountAnimationEnd이 실행되면 unmountCallback을 수행할 수 있다.', () => {
     const unmountCallback = jest.fn();
     const { result } = renderHook(() => _useAnimation(MOUNT_ANIMATION_CLASSNAME, UNMOUNT_ANIMATION_CLASSNAME, unmountCallback));
-    expect(result.current.animationClassName).toBe(MOUNT_ANIMATION_CLASSNAME);
     act(() => result.current.triggerUnmountAnimation());
     expect(result.current.animationClassName).toBe(UNMOUNT_ANIMATION_CLASSNAME);
     act(() => result.current.handleUnmountAnimationEnd());

--- a/src/useAnimation/useAnimation.test.tsx
+++ b/src/useAnimation/useAnimation.test.tsx
@@ -1,25 +1,70 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import useAnimation from './useAnimation';
 import React from 'react';
+
+const Test = () => {
+  const { show, AnimationWrapper, hide } = useAnimation({
+    mountClassName: 'show',
+    unmountClassName: 'hide',
+  });
+  return (
+    <>
+      <AnimationWrapper>
+        <div>테스트</div>
+      </AnimationWrapper>
+      <button onClick={show}>Show</button>
+      <button onClick={hide}>Hide</button>
+    </>
+  );
+};
+
+const TestNoHide = () => {
+  const { show, AnimationWrapper, hide } = useAnimation({
+    mountClassName: 'show',
+  });
+  return (
+    <>
+      <AnimationWrapper>
+        <div>테스트</div>
+      </AnimationWrapper>
+      <button onClick={show}>Show</button>
+      <button onClick={hide}>Hide</button>
+    </>
+  );
+};
+
 describe('useAnimation 테스트', () => {
-  it('show를 호출 AnimationWrapper의 children이 화면에 보인다.', () => {
-    const Test = () => {
-      const { show, AnimationWrapper } = useAnimation({
-        mountClassName: 'show',
-        unmountClassName: 'hide',
-      });
-      return (
-        <>
-          <AnimationWrapper>
-            <div>테스트</div>
-          </AnimationWrapper>
-          <button onClick={show}>Click</button>
-        </>
-      );
-    };
-    render(<Test />);
+  it('버튼을 누르면 AnimationWrapper에 className이 show로 변하고, 화면에 내용이 보인다.', () => {
+    const { container } = render(<Test />);
     expect(() => screen.getByText('테스트')).toThrow();
-    fireEvent.click(screen.getByText('Click'));
+    fireEvent.click(screen.getByText('Show'));
     expect(screen.getByText('테스트')).toBeTruthy();
+    expect(container.querySelector('.show')).toBeTruthy();
+  });
+
+  it('hide버튼을 누르면 AnimationWrapper에 className이 hide로 변하고, 화면에 내용이 보이지 않는다.', () => {
+    const { container } = render(<Test />);
+    fireEvent.click(screen.getByText('Show'));
+    expect(container.querySelector('.show')).toBeTruthy();
+    expect(screen.getByText('테스트')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Hide'));
+    expect(container.querySelector('.hide')).toBeTruthy();
+
+    fireEvent.animationEnd(container.querySelector('div')!);
+    expect(() => screen.getByText('테스트')).toThrow();
+  });
+
+  it('hide className이 없는 경우, hide버튼 클릭시 AnimationWrapper의 className이 지정되지 않고, 화면에 내용이 보이지 않는다.', () => {
+    const { container } = render(<TestNoHide />);
+    fireEvent.click(screen.getByText('Show'));
+    expect(container.querySelector('.show')).toBeTruthy();
+    expect(screen.getByText('테스트')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Hide'));
+    expect(container.querySelector('.hide')).toBeFalsy();
+
+    fireEvent.animationEnd(container.querySelector('div')!);
+    expect(() => screen.getByText('테스트')).toThrow();
   });
 });


### PR DESCRIPTION
- [x] useAnimation test coverage 개선

### Before
![image](https://github.com/Rapiders/react-hooks/assets/99241871/303cb33b-2fb6-41ef-ab20-e79a21e00f8a)

### After
![image](https://github.com/Rapiders/react-hooks/assets/99241871/913eb7d4-ab60-40ad-a134-f8501b43dbed)

useAnimation 훅에서 커버되지않고 있던 코드에 대한 테스트코드를 추가하였습니다.
